### PR TITLE
Only permit geodetics-0.1 series

### DIFF
--- a/geocoordinate.cabal
+++ b/geocoordinate.cabal
@@ -58,7 +58,7 @@ library geocoordinate-internal
     , containers
     , deepseq >=1.4 && <=1.6
     , dimensional
-    , geodetics
+    , geodetics >=0.1 && <1.0
     , geohash
   default-language: Haskell2010
   if flag(ci)

--- a/package.yaml
+++ b/package.yaml
@@ -85,7 +85,7 @@ internal-libraries:
       - containers
       - deepseq >= 1.4 && <= 1.6
       - dimensional
-      - geodetics
+      - geodetics >= 0.1 && < 1.0
       - geohash
 
 tests:


### PR DESCRIPTION
I was playing around with this library and I noticed it doesn't work with geodetics-1.0 or 1.1. So let's add the bound such that cabal-install users automatically get a working version of this dependency.
